### PR TITLE
Add const to member functions and pass by const ref

### DIFF
--- a/src/duckx.cpp
+++ b/src/duckx.cpp
@@ -29,15 +29,15 @@ void duckx::Run::set_current(pugi::xml_node node) {
 }
 
 
-std::string duckx::Run::get_text() {
+std::string duckx::Run::get_text() const {
     return this->current.child("w:t").text().get();
 }
 
-bool duckx::Run::set_text(std::string text) {
+bool duckx::Run::set_text(std::string text) const {
     return this->current.child("w:t").text().set(text.c_str());
 }
 
-bool duckx::Run::set_text(const char *text) {
+bool duckx::Run::set_text(const char *text) const {
     return this->current.child("w:t").text().set(text);
 }
 
@@ -46,7 +46,7 @@ duckx::Run& duckx::Run::next() {
     return *this;
 }
 
-bool duckx::Run::has_next() {
+bool duckx::Run::has_next() const {
     return this->current != 0;
 }
 
@@ -71,7 +71,7 @@ void duckx::TableCell::set_current(pugi::xml_node node) {
 	this->current = node;
 }
 
-bool duckx::TableCell::has_next() {
+bool duckx::TableCell::has_next() const {
 	return this->current != 0;
 }
 
@@ -120,7 +120,7 @@ duckx::TableCell& duckx::TableRow::cells() {
 	return this->cell;
 }
 
-bool duckx::TableRow::has_next() {
+bool duckx::TableRow::has_next() const {
 	return this->current != 0;
 }
 
@@ -141,7 +141,7 @@ void duckx::Table::set_parent(pugi::xml_node node) {
 	);
 }
 
-bool duckx::Table::has_next() {
+bool duckx::Table::has_next() const {
 	return this->current != 0;
 }
 
@@ -188,7 +188,7 @@ duckx::Paragraph &duckx::Paragraph::next() {
     return *this;
 }
 
-bool duckx::Paragraph::has_next() {
+bool duckx::Paragraph::has_next() const {
     return this->current != 0;
 }
 
@@ -263,7 +263,7 @@ void duckx::Document::open() {
     );
 }
 
-void duckx::Document::save() {
+void duckx::Document::save() const {
 	// minizip only supports appending or writing to new files
 	// so we must
 	// - make a new file

--- a/src/duckx.cpp
+++ b/src/duckx.cpp
@@ -33,7 +33,7 @@ std::string duckx::Run::get_text() const {
     return this->current.child("w:t").text().get();
 }
 
-bool duckx::Run::set_text(std::string text) const {
+bool duckx::Run::set_text(const std::string& text) const {
     return this->current.child("w:t").text().set(text.c_str());
 }
 
@@ -199,7 +199,7 @@ duckx::Run &duckx::Paragraph::runs() {
     return this->run;
 }
 
-duckx::Run &duckx::Paragraph::add_run(std::string text) {
+duckx::Run &duckx::Paragraph::add_run(const std::string& text) {
     return this->add_run(text.c_str());
 }
 
@@ -214,7 +214,7 @@ duckx::Run &duckx::Paragraph::add_run(const char *text) {
     return *new Run(this->current, new_run);
 }
 
-duckx::Paragraph &duckx::Paragraph::insert_paragraph_after(std::string text) {
+duckx::Paragraph &duckx::Paragraph::insert_paragraph_after(const std::string& text) {
     pugi::xml_node new_para = this->parent.insert_child_after("w:p", this->current);
     
     Paragraph *p = new Paragraph();

--- a/src/duckx.hpp
+++ b/src/duckx.hpp
@@ -33,7 +33,7 @@ namespace duckx {
         void set_current(pugi::xml_node);
 
         std::string get_text() const;
-        bool set_text(std::string) const;
+        bool set_text(const std::string&) const;
         bool set_text(const char *) const;
 
         Run &next();
@@ -61,9 +61,9 @@ namespace duckx {
         bool has_next() const;
 
         Run &runs();
-        Run &add_run(std::string);
+        Run &add_run(const std::string&);
         Run &add_run(const char*);
-        Paragraph &insert_paragraph_after(std::string);
+        Paragraph &insert_paragraph_after(const std::string&);
     };
 
 	// TableCell contains one or more paragraphs

--- a/src/duckx.hpp
+++ b/src/duckx.hpp
@@ -32,12 +32,12 @@ namespace duckx {
         void set_parent(pugi::xml_node);
         void set_current(pugi::xml_node);
 
-        std::string get_text();
-        bool set_text(std::string);
-        bool set_text(const char *);
+        std::string get_text() const;
+        bool set_text(std::string) const;
+        bool set_text(const char *) const;
 
         Run &next();
-        bool has_next();
+        bool has_next() const;
     };
 
     // Paragraph contains a paragraph
@@ -58,7 +58,7 @@ namespace duckx {
         void set_current(pugi::xml_node);
 
         Paragraph &next();
-        bool has_next();
+        bool has_next() const;
 
         Run &runs();
         Run &add_run(std::string);
@@ -83,7 +83,7 @@ namespace duckx {
 		Paragraph& paragraphs();
 
 		TableCell& next();
-		bool has_next();
+		bool has_next() const;
 	};
 
 	// TableRow consists of one or more TableCells
@@ -100,7 +100,7 @@ namespace duckx {
 
 		TableCell& cells();
 
-		bool has_next();
+		bool has_next() const;
 		TableRow& next();
 	};
 
@@ -118,7 +118,7 @@ namespace duckx {
 		void set_current(pugi::xml_node);
 
 		Table& next();
-		bool has_next();
+		bool has_next() const;
 
 		TableRow& rows();
 	};
@@ -137,7 +137,7 @@ namespace duckx {
         Document(std::string);
         void file(std::string);
         void open();
-        void save();
+        void save() const;
 
         Paragraph &paragraphs();
 		Table& tables();


### PR DESCRIPTION
If you do decide on having C++11 be the min then `Document::Document` and `Document::file` could move the parameter.