### PR TITLE
Fix errors building on clang 12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,11 @@ endif()
 option(BUILD_SHARED_LIBS "Build shared instead of static library" OFF)
 option(BUILD_SAMPLES "Build provided samples" OFF)
 
+# Fix issues when building with clang 12, next version of clang
+# else we might encounter errors making the library 
+# not being able to be compiled
+
+set(CMAKE_CXX_STANDARD 11)
 
 set(HEADERS "${CMAKE_SOURCE_DIR}/include/duckx.hpp"
             "${CMAKE_SOURCE_DIR}/include/constants.hpp"


### PR DESCRIPTION
Hi! Thanks a lot for your library, well.

The issue is I am using clang 12, and macOS Big Sur.

```
Configured with: --prefix=/Applications/Xcode-beta.app/Contents/Developer/usr --with-gxx-include-dir=/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/4.2.1
Apple clang version 12.0.0 (clang-1200.0.32.6)
Target: x86_64-apple-darwin20.1.0
Thread model: posix
InstalledDir: /Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin`
```

This includes the new version of clang, aka clang 12. While this project is amazing and easy to use!, it is unable to compile without this line of code, here are the following errors:

```
❯ cmake --build .

[ 14%] Building CXX object CMakeFiles/duckx.dir/src/duckx.cpp.o
In file included from /Users/me/Downloads/DuckX/src/duckx.cpp:1:
In file included from /Users/me/Downloads/DuckX/include/duckx.hpp:15:
/Users/me/Downloads/DuckX/include/duckxiterator.hpp:17:24: warning: alias
      declarations are a C++11 extension [-Wc++11-extensions]
    using ParentType = P;
                       ^
/Users/me/Downloads/DuckX/include/duckxiterator.hpp:18:25: warning: alias
      declarations are a C++11 extension [-Wc++11-extensions]
    using CurrentType = C;
                        ^
/Users/me/Downloads/DuckX/include/duckxiterator.hpp:19:16: error: function
      definition does not declare parameters
    ParentType parent{0};
               ^
/Users/me/Downloads/DuckX/include/duckxiterator.hpp:20:17: error: function
      definition does not declare parameters
    CurrentType current{0};
                ^
/Users/me/Downloads/DuckX/include/duckxiterator.hpp:21:15: error: function
      definition does not declare parameters
    mutable T buffer{};
              ^
/Users/me/Downloads/DuckX/include/duckxiterator.hpp:24:18: warning: defaulted
      function definitions are a C++11 extension [-Wc++11-extensions]
    Iterator() = default;
                 ^
/Users/me/Downloads/DuckX/include/duckxiterator.hpp:42:5: warning: 'auto' type
      specifier is a C++11 extension [-Wc++11-extensions]
    auto operator*() const -> T const & {
    ^
/Users/me/Downloads/DuckX/include/duckxiterator.hpp:42:5: error: 'auto' not
      allowed in function return type
    auto operator*() const -> T const & {
    ^~~~
/Users/me/Downloads/DuckX/include/duckxiterator.hpp:42:27: error: expected ';'
      at end of declaration list
    auto operator*() const -> T const & {
                          ^
                          ;
/Users/me/Downloads/DuckX/include/duckxiterator.hpp:27:11: error: member
      initializer 'parent' does not name a non-static data member or base class
        : parent(parent), current(current) {}
          ^~~~~~~~~~~~~~
/Users/me/Downloads/DuckX/include/duckxiterator.hpp:27:27: error: member
      initializer 'current' does not name a non-static data member or base class
        : parent(parent), current(current) {}
                          ^~~~~~~~~~~~~~~~
/Users/me/Downloads/DuckX/include/duckxiterator.hpp:30:16: error: use of
      undeclared identifier 'parent'
        return parent != other.parent || current != other.current;
               ^
/Users/me/Downloads/DuckX/include/duckxiterator.hpp:30:42: error: use of
      undeclared identifier 'current'
        return parent != other.parent || current != other.current;
                                         ^
/Users/me/Downloads/DuckX/include/duckxiterator.hpp:54:15: warning: alias
      declarations are a C++11 extension [-Wc++11-extensions]
    using P = pugi::xml_node;
              ^
/Users/me/Downloads/DuckX/include/duckxiterator.hpp:55:31: warning: 'auto' type
      specifier is a C++11 extension [-Wc++11-extensions]
    template <class T> static auto make_begin(T const &obj) -> Iterator<T, P> {
                              ^
/Users/me/Downloads/DuckX/include/duckxiterator.hpp:55:31: error: 'auto' not
      allowed in function return type
    template <class T> static auto make_begin(T const &obj) -> Iterator<T, P> {
                              ^~~~
/Users/me/Downloads/DuckX/include/duckxiterator.hpp:55:60: error: expected ';'
      at end of declaration list
    template <class T> static auto make_begin(T const &obj) -> Iterator<T, P> {
                                                           ^
                                                           ;
/Users/me/Downloads/DuckX/include/duckxiterator.hpp:65:31: warning: 'auto' type
      specifier is a C++11 extension [-Wc++11-extensions]
    template <class T> friend auto end(T const &) -> Iterator<T, P>;
                              ^
/Users/me/Downloads/DuckX/include/duckxiterator.hpp:65:31: error: 'auto' not
      allowed in function return type
    template <class T> friend auto end(T const &) -> Iterator<T, P>;
                              ^~~~
/Users/me/Downloads/DuckX/include/duckxiterator.hpp:65:50: error: expected ';'
      at end of declaration list
    template <class T> friend auto end(T const &) -> Iterator<T, P>;
                                                 ^
                                                 ;
/Users/me/Downloads/DuckX/include/duckxiterator.hpp:69:20: warning: 'auto' type
      specifier is a C++11 extension [-Wc++11-extensions]
template <class T> auto begin(T const &obj) -> Iterator<T, pugi::xml_node> {
                   ^
/Users/me/Downloads/DuckX/include/duckxiterator.hpp:69:20: error: 'auto' not
      allowed in function return type
template <class T> auto begin(T const &obj) -> Iterator<T, pugi::xml_node> {
                   ^~~~
/Users/me/Downloads/DuckX/include/duckxiterator.hpp:69:44: error: expected ';'
      at end of declaration
template <class T> auto begin(T const &obj) -> Iterator<T, pugi::xml_node> {
                                           ^
                                           ;
/Users/me/Downloads/DuckX/include/duckxiterator.hpp:69:45: error: cannot use
      arrow operator on a type
template <class T> auto begin(T const &obj) -> Iterator<T, pugi::xml_node> {
                                            ^
/Users/me/Downloads/DuckX/include/duckxiterator.hpp:73:20: warning: 'auto' type
      specifier is a C++11 extension [-Wc++11-extensions]
template <class T> auto end(T const &obj) -> Iterator<T, pugi::xml_node> {
                   ^
/Users/me/Downloads/DuckX/include/duckxiterator.hpp:73:20: error: 'auto' not
      allowed in function return type
template <class T> auto end(T const &obj) -> Iterator<T, pugi::xml_node> {
                   ^~~~
/Users/me/Downloads/DuckX/include/duckxiterator.hpp:73:42: error: expected ';'
      at end of declaration
template <class T> auto end(T const &obj) -> Iterator<T, pugi::xml_node> {
                                         ^
                                         ;
/Users/me/Downloads/DuckX/include/duckxiterator.hpp:73:43: error: cannot use
```

This is fixed as soon as this line is added, making it being able to use the C11 extension it is requested.

Hope this can be merged so both clang and gcc user can use this awesome library! Greetings!
