### PR TITLE
Libzip buffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ build/*
 
 # vim swap files
 **/*.swp
+
+# dev script
+scr.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,13 +21,13 @@ set(HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/include/duckx.hpp"
 set(SOURCES src/duckx.cpp)
 
 set(THIRD_PARTY_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/pugixml/pugixml.hpp"
-                        "${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/pugixml/pugiconfig.hpp"
-                        "${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/zip/zip.h")
-set(THIRD_PARTY_SRC "${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/zip/zip.c")
+                        "${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/pugixml/pugiconfig.hpp")
+#                        "${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/zip/zip.h")
+#set(THIRD_PARTY_SRC "${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/zip/zip.c")
 
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include"
-                    "${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/pugixml"
-                    "${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/zip")
+                    "${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/pugixml")
+                    #"${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/zip")
 
 if(BUILD_SHARED_LIBS)
     add_library(duckx SHARED ${SOURCES} ${THIRD_PARTY_SRC})
@@ -36,6 +36,8 @@ else()
 endif()
 
 add_library(duckx::duckx ALIAS duckx)
+
+target_link_libraries(duckx zip)
 
 target_include_directories(duckx PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ cmake --build .
 
 ## Requirements ##
 
-- [zip](https://github.com/kuba--/zip)
+- [libzip](https://github.com/nih-at/libzip)
 - [pugixml](https://github.com/zeux/pugixml)
 
 

--- a/include/duckx.hpp
+++ b/include/duckx.hpp
@@ -160,15 +160,14 @@ class Document {
     Paragraph paragraph;
     Table table;
     pugi::xml_document document;
-    zip_error_t zipError;
+    zip_error_t zip_error;
     int *errorp;
-    zip_file_t* docFile = NULL;
     zip_t* zip = NULL;
     char* buf;
-    size_t bufLen;
+    size_t buf_len;
     //the only way I know to write to zip is wait for zip_close, 
     //so we need to keep writers in order to flush it's contents to actual file
-    std::vector<std::shared_ptr<xml_string_writer>> saveWriters; 
+    std::vector<std::shared_ptr<xml_string_writer>> save_writers; 
 
   public:
     Document();

--- a/include/duckx.hpp
+++ b/include/duckx.hpp
@@ -7,6 +7,7 @@
 #ifndef DUCKX_H
 #define DUCKX_H
 
+#include <bits/stdc++.h>
 #include <cstdio>
 #include <stdlib.h>
 #include <string>
@@ -16,7 +17,18 @@
 #include <pugixml.hpp>
 #include <zip.h>
 
+#define PROD
+
+#ifndef PROD
+#define DEBUG(x) cout << "[DEBUG] " << #x << ": " << (x) << endl;
+#else
+#define DEBUG
+#endif
+
 // TODO: Use container-iterator design pattern!
+
+struct xml_string_writer;
+
 
 namespace duckx {
 // Run contains runs in a paragraph
@@ -133,22 +145,42 @@ class Table {
     TableRow &rows();
 };
 
+enum class MODE {
+    FILE,
+    BUFFER,
+};
+
 // Document contains whole the docx file
 // and stores paragraphs
 class Document {
   private:
     friend class IteratorHelper;
     std::string directory;
+    MODE mode;
     Paragraph paragraph;
     Table table;
     pugi::xml_document document;
+    zip_error_t zipError;
+    int *errorp;
+    zip_file_t* docFile = NULL;
+    zip_t* zip = NULL;
+    char* buf;
+    size_t bufLen;
+    //the only way I know to write to zip is wait for zip_close, 
+    //so we need to keep writers in order to flush it's contents to actual file
+    std::vector<std::shared_ptr<xml_string_writer>> saveWriters; 
 
   public:
     Document();
+    ~Document();
     Document(std::string);
+    Document(char*, size_t);
     void file(std::string);
+    void buffer(char*, size_t);
     void open();
-    void save() const;
+    void close();
+    void save(const char* dst = NULL);
+    //void save(const char*) const;
 
     Paragraph &paragraphs();
     Table &tables();


### PR DESCRIPTION
DuckX is using miniz library, which is unable to parse zip archive in-memory (from char*), hence I rewrote some pieces of code using libzip, and extended functionality of save method with capability to save to another files. The code is quite raw and slightly tested, but I decided to open pull request now in order to discuss upcoming changes. The most unsolved issue is an addition of libzip library using cmake (I don't know how to do it).